### PR TITLE
Based on WGLC comments, add network-type, move port-breakout, and link-type identities

### DIFF
--- a/draft-ietf-ivy-network-inventory-topology.md
+++ b/draft-ietf-ivy-network-inventory-topology.md
@@ -114,7 +114,7 @@ The inventory topology data model can be used as a basis for correlating
    which can be used to check the availability and capacity of physical
    ports.
 
-~~~~ ascii-art
+~~~~ aasvg
                         +-----------------+
                         |     Customer    |
                         +--------+--------+
@@ -326,7 +326,7 @@ Scenario: Device "SW-1" and device "SW-2" are directly connected by a fiber.
 
 Physical topology:
 
-~~~~ ascii-art
+~~~~ aasvg
 .--------.                                    .--------.
 |        |                                    |        |
 |  SW-1  +========= fiber link ===============+  SW-2  |

--- a/draft-ietf-ivy-network-inventory-topology.md
+++ b/draft-ietf-ivy-network-inventory-topology.md
@@ -114,7 +114,7 @@ The inventory topology data model can be used as a basis for correlating
    which can be used to check the availability and capacity of physical
    ports.
 
-~~~~ aasvg
+~~~~ ascii-art
                         +-----------------+
                         |     Customer    |
                         +--------+--------+
@@ -326,7 +326,7 @@ Scenario: Device "SW-1" and device "SW-2" are directly connected by a fiber.
 
 Physical topology:
 
-~~~~ aasvg
+~~~~ ascii-art
 .--------.                                    .--------.
 |        |                                    |        |
 |  SW-1  +========= fiber link ===============+  SW-2  |

--- a/yang/full-trees/ietf-network-inventory-topology.tree
+++ b/yang/full-trees/ietf-network-inventory-topology.tree
@@ -1,16 +1,18 @@
 
 module: ietf-network-inventory-topology
+
+  augment /nw:networks/nw:network/nw:network-types:
+    +--rw inventory-topology!
   augment /nw:networks/nw:network/nw:node:
     +--rw inventory-mapping-attributes
        +--rw ne-ref?   nwi:ne-ref
   augment /nw:networks/nw:network/nt:link:
     +--rw inventory-mapping-attributes
-       +--rw link-type?   string
+       +--rw link-type?   identityref
   augment /nw:networks/nw:network/nw:node/nt:termination-point:
     +--rw inventory-mapping-attributes
-       +--rw ne-ref?          nwi:ne-ref
-       +--rw port-ref?        leafref
-       +--ro port-breakout!
-          +--ro breakout-channel* [channel-id]
-             +--ro channel-id    uint16
-
+    |  +--rw ne-ref?     nwi:ne-ref
+    |  +--rw port-ref?   leafref
+    +--ro port-breakout!
+       +--ro breakout-channel* [channel-id]
+          +--ro channel-id    uint16

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -192,7 +192,7 @@ module ietf-network-inventory-topology {
 
            This leaf serves as a lightweight discriminator.  When the
            value is 'microwave', detailed microwave link attributes
-           are defined in the microwave topology model (RFC 9656).
+           are defined in the microwave topology data model.
            For wired media (fiber, copper, coax), detailed passive
            inventory attributes are defined in the passive network
       }

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -65,13 +65,87 @@ module ietf-network-inventory-topology {
                  Mapping";
   }
 
-  // Groupings
-  // Node Grouping with 1:1 mapping to NE
-
-  grouping node-inventory-mapping-attributes {
+  identity link-type {
     description
-      "Attributes for mapping a topology node to a Network Element
-       (NE) in the physical inventory.";
+      "Base identity for classifying the physical media type of a
+       link at the inventory topology layer.  Specialized inventory
+       models are expected to define derived identities for specific
+       media, e.g., fiber, copper, or wireless.";
+  }
+
+  identity copper {
+    base link-type;
+    description
+      "Copper-based physical link.";
+  }
+
+  identity fiber {
+    base link-type;
+    description
+      "Fiber-based physical link.";
+  }
+
+  identity coax {
+    base link-type;
+    description
+      "Coaxial cable-based physical link.";
+  }
+
+  identity microwave {
+    base link-type;
+    description
+      "Microwave-based wireless link.
+       Detailed microwave radio attributes are defined in the
+       microwave topology model (RFC 9656).";
+  }
+
+  identity wifi {
+    base link-type;
+    description
+      "Wi-Fi (IEEE 802.11) wireless link.";
+  }
+
+  identity unknown {
+    base link-type;
+    description
+      "The link media type is unknown or could not be determined.
+       This identity is used as a fallback when the physical medium
+       cannot be classified into any of the currently defined types.";
+  }
+
+  identity leased-fiber {
+    base fiber;
+    description
+      "Leased fiber link.  The physical medium is fiber, but the link
+       is provided by a third-party operator.  Detailed physical
+       attributes are typically not visible to the lessee.";
+  }
+
+  // Main blocks
+
+  augment "/nw:networks/nw:network/nw:network-types" {
+    description
+      "Introduces a new network type for inventory topology mapping.";
+    container inventory-topology {
+      presence
+        "Indicates this is a bottom-most physical topology instance,
+         containing physical-layer attributes including inventory
+         mapping, port breakout capabilities, and link media types.";
+      description
+        "Container for the inventory-topology network type.
+         When present, it signals that the network contains
+         physical-layer augmentations as defined in this module.
+         This network type is intended to serve as the underlay
+         for logical network topologies (L2, L3, TE, etc.).";
+    }
+  }
+
+  augment "/nw:networks/nw:network/nw:node" {
+    when '../nw:network-types/nwit:inventory-topology';
+    description
+      "Augments the network topology node with inventory mapping
+       attributes. This enables correlation between the logical node
+       and its physical network element.";
     container inventory-mapping-attributes {
       description
         "Container for inventory mapping attributes of a node.";
@@ -87,60 +161,11 @@ module ietf-network-inventory-topology {
     }
   }
 
-  // TP Grouping with 1:1 mapping to physical port
-
-  grouping tp-inventory-mapping-attributes {
+  augment "/nw:networks/nw:network/nt:link" {
+    when '../nw:network-types/nwit:inventory-topology';
     description
-      "Attributes for mapping a topology termination point (TP)
-       to a physical port in the network inventory.";
-    container inventory-mapping-attributes {
-      description
-        "Container for inventory mapping attributes of a TP.";
-      uses nwi:port-ref {
-        refine "port-ref" {
-          description
-            "Reference to the physical port component in the
-             network inventory. This reference establishes a 1:1
-             mapping between the logical TP and its physical port
-             component.";
-        }
-      }
-      // breakout channels (lightweight, per physical port)
-      container port-breakout {
-        presence "Indicates the port supports channel breakout.";
-        config false;
-        description
-          "Breakout capability of the physical port represented by
-           this TP. One TP maps to one physical port; channels are
-           listed here. This container is present only when the
-           underlying hardware supports partitioning the port into
-           multiple independent channels (e.g., 400G to 4x100G).";
-        list breakout-channel {
-          key "channel-id";
-          description
-            "List of breakout channels available on this port.
-             Each entry represents an independent lane or sub-port
-             that can be used for channelized interfaces.";
-          leaf channel-id {
-            type uint16;
-            description
-              "Unique identifier for the breakout channel within the
-               scope of the parent port.";
-          }
-        } // breakout-channel
-      } // port-breakout
-    }
-  }
-
-  // Link Grouping  with placeholder for future augumentation
-
-  grouping link-inventory-mapping-attributes {
-    description
-      "Attributes for classifying link media type.
-       Detailed inventory reference is intentionally omitted from
-       this model; implementations should use the appropriate
-       specialized inventory modules based on the indicated
-       link-type.";
+      "Augments the network topology link with inventory-related
+       attributes.";
     container inventory-mapping-attributes {
       description
         "Container for inventory-related attributes of a link.
@@ -156,36 +181,66 @@ module ietf-network-inventory-topology {
            Detailed inventory references may be added in future
            modules.";
       leaf link-type {
-        type string;
+        type identityref {
+          base link-type;
+        }
         description
-          "Classification of the link media type at the topology
-           layer. Example values include 'copper', 'fiber',
-           'microwave', or 'wifi'.";
+          "Classification of the link media type at the topology layer.
+           The base identity 'link-type' is extensible; currently defined
+           derived identities include 'copper', 'fiber', 'coax',
+           'microwave', and 'wifi'.
+
+           This leaf serves as a lightweight discriminator.  When the
+           value is 'microwave', detailed microwave link attributes
+           are defined in the microwave topology model (RFC 9656).
+           For wired media (fiber, copper, coax), detailed passive
+           inventory attributes are defined in the passive network
+           inventory model.";
       }
     }
   }
 
-  // Main blocks
-
-  augment "/nw:networks/nw:network/nw:node" {
-    description
-      "Augments the network topology node with inventory mapping
-       attributes. This enables correlation between the logical node
-       and its physical network element.";
-    uses node-inventory-mapping-attributes;
-  }
-
-  augment "/nw:networks/nw:network/nt:link" {
-    description
-      "Augments the network topology link with inventory-related
-       attributes.";
-    uses link-inventory-mapping-attributes;
-  }
-
   augment "/nw:networks/nw:network/nw:node/nt:termination-point" {
+    when '../../nw:network-types/nwit:inventory-topology';
     description
-      "Augments the TP with inventory mapping attributes for
-       physical port correlation and breakout capability reporting.";
-    uses tp-inventory-mapping-attributes;
+      "Augments the TP with inventory mapping and port breakout.";
+    container inventory-mapping-attributes {
+      description
+        "Container for inventory mapping attributes of a TP.";
+      uses nwi:port-ref {
+        refine "port-ref" {
+          description
+            "Reference to the physical port component in the
+             network inventory. This reference establishes a 1:1
+             mapping between the logical TP and its physical port
+             component.";
+        }
+      }
+    }
+    // breakout channels (lightweight, per physical port)
+    container port-breakout {
+      presence "Indicates the port supports channel breakout.";
+      config false;
+      description
+        "Breakout capability of the physical port represented by
+         this TP. One TP maps to one physical port; channels are
+         listed here. This container is present only when the
+         underlying hardware supports partitioning the port into
+         multiple independent channels (e.g., 400G to 4x100G).";
+      list breakout-channel {
+        key "channel-id";
+        description
+          "List of breakout channels available on this port.
+           Each entry represents an independent lane or sub-port
+           that can be used for channelized interfaces.";
+        leaf channel-id {
+          type uint16;
+          description
+            "Unique identifier for the breakout channel within the
+             scope of the parent port.";
+        }
+      } // breakout-channel
+    } // port-breakout       
   }
 }
+

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -195,7 +195,6 @@ module ietf-network-inventory-topology {
            are defined in the microwave topology model (RFC 9656).
            For wired media (fiber, copper, coax), detailed passive
            inventory attributes are defined in the passive network
-           inventory model.";
       }
     }
   }

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -188,7 +188,7 @@ module ietf-network-inventory-topology {
           "Classification of the link media type at the topology layer.
            The base identity 'link-type' is extensible; currently defined
            derived identities include 'copper', 'fiber', 'coax',
-           'microwave', and 'wifi'.
+           'microwave', and 'wlan'.
 
            This leaf serves as a lightweight discriminator.  When the
            value is 'microwave', detailed microwave link attributes

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -110,7 +110,7 @@ module ietf-network-inventory-topology {
     description
       "The link media type is unknown or could not be determined.
        This identity is used as a fallback when the physical medium
-       cannot be classified into any of the currently defined types.";
+       cannot be classified into any of the other defined types.";
   }
 
   identity leased-fiber {

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -194,7 +194,7 @@ module ietf-network-inventory-topology {
            value is 'microwave', detailed microwave link attributes
            are defined in the microwave topology data model.
            Wired media (e.g., fiber, copper, or coax) may be detailed in
-           inventory attributes are defined in the passive network
+          a passive network inventory data model.";
       }
     }
   }

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -193,7 +193,7 @@ module ietf-network-inventory-topology {
            This leaf serves as a lightweight discriminator.  When the
            value is 'microwave', detailed microwave link attributes
            are defined in the microwave topology data model.
-           For wired media (fiber, copper, coax), detailed passive
+           Wired media (e.g., fiber, copper, or coax) may be detailed in
            inventory attributes are defined in the passive network
       }
     }

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -99,7 +99,7 @@ module ietf-network-inventory-topology {
        microwave topology model (RFC 9656).";
   }
 
-  identity wifi {
+  identity wlan {
     base link-type;
     description
       "Wi-Fi (IEEE 802.11) wireless link.";


### PR DESCRIPTION
Add network-type “inventory-topology”, move port-breakout outside of inventory-mapping, and link-type identities