### PR TITLE
Added presence container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ draft-ietf-ivy-network-inventory-topology.xml
 package-lock.json
 report.xml
 !requirements.txt
+*.bash
+temp/

--- a/draft-ietf-ivy-network-inventory-topology.md
+++ b/draft-ietf-ivy-network-inventory-topology.md
@@ -91,6 +91,7 @@ Please apply the following replacements:
 
   * XXXX --> the assigned RFC number for this I-D
   * AAAA --> the assigned RFC number for {{!I-D.ietf-ivy-network-inventory-yang}}
+  * 2026-05-18 --> the actual date of the publication of this document
 
 # Conventions and Definitions
 
@@ -242,7 +243,7 @@ This module imports the base network inventory {{!I-D.ietf-ivy-network-inventory
 ~~~~ yang
 {::include-fold ./yang/ietf-network-inventory-topology.yang}
 ~~~~
-{: sourcecode-markers="true" sourcecode-name="ietf-network-inventory-topology@2026-02-28.yang"}
+{: sourcecode-markers="true" sourcecode-name="ietf-network-inventory-topology@2026-05-18.yang"}
 
 # Operational Considerations
 

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -57,7 +57,7 @@ module ietf-network-inventory-topology {
      This version of this YANG module is part of RFC XXXX; see
      the RFC itself for full legal notices.";
 
-  revision 2026-02-28 {
+  revision 2026-05-18 {
     description
       "Initial revision.";
     reference
@@ -128,9 +128,9 @@ module ietf-network-inventory-topology {
       "Introduces a new network type for inventory topology mapping.";
     container inventory-topology {
       presence
-        "Indicates this is a bottom-most physical topology instance,
-         containing physical-layer attributes including inventory
-         mapping, port breakout capabilities, and link media types.";
+        "Indicates a physical network topology, containing
+         physical-layer attributes including inventory mapping, port
+         breakout capabilities, and link media types.";
       description
         "Container for the inventory-topology network type.
          When present, it signals that the network contains
@@ -147,6 +147,9 @@ module ietf-network-inventory-topology {
        attributes. This enables correlation between the logical node
        and its physical network element.";
     container inventory-mapping-attributes {
+      presence
+        "Indicates a physical node, at the lowest underlay
+         abstraction level.";
       description
         "Container for inventory mapping attributes of a node.";
       leaf ne-ref {
@@ -167,6 +170,9 @@ module ietf-network-inventory-topology {
       "Augments the network topology link with inventory-related
        attributes.";
     container inventory-mapping-attributes {
+      presence
+        "Indicates a physical link, at the lowest underlay
+         abstraction level.";
       description
         "Container for inventory-related attributes of a link.
 
@@ -204,6 +210,9 @@ module ietf-network-inventory-topology {
     description
       "Augments the TP with inventory mapping and port breakout.";
     container inventory-mapping-attributes {
+      presence
+        "Indicates a physical termination point (TP), at the lowest
+         underlay abstraction level.";
       description
         "Container for inventory mapping attributes of a TP.";
       uses nwi:port-ref {

--- a/yang/ietf-network-inventory-topology.yang
+++ b/yang/ietf-network-inventory-topology.yang
@@ -57,7 +57,7 @@ module ietf-network-inventory-topology {
      This version of this YANG module is part of RFC XXXX; see
      the RFC itself for full legal notices.";
 
-  revision 2026-05-18 {
+  revision 2026-06-10 {
     description
       "Initial revision.";
     reference
@@ -148,8 +148,9 @@ module ietf-network-inventory-topology {
        and its physical network element.";
     container inventory-mapping-attributes {
       presence
-        "Indicates a physical node, at the lowest underlay
-         abstraction level.";
+        "If present, it indicates this is a physical node, which
+         maps to a network element. If not present, it indicates it
+         is an abstract node.";
       description
         "Container for inventory mapping attributes of a node.";
       leaf ne-ref {
@@ -211,8 +212,9 @@ module ietf-network-inventory-topology {
       "Augments the TP with inventory mapping and port breakout.";
     container inventory-mapping-attributes {
       presence
-        "Indicates a physical termination point (TP), at the lowest
-         underlay abstraction level.";
+        "If present, it indicates this is a physical termination
+         point (TP), which maps to a port component. If not present,
+         it indicates it is a logical TP.";
       description
         "Container for inventory mapping attributes of a TP.";
       uses nwi:port-ref {

--- a/yang/ietf-network-inventory.yang
+++ b/yang/ietf-network-inventory.yang
@@ -23,7 +23,7 @@ module ietf-network-inventory {
     "IETF IVY Working Group";
   contact
     "WG Web:   <https://datatracker.ietf.org/wg/ivy/>
-     WG List:  <mailto:inventory-yang@ietf.org>
+     WG List:  <mailto:ivy@ietf.org>
 
      Editor:   Chaode Yu
                <yuchaode@huawei.com>
@@ -65,7 +65,7 @@ module ietf-network-inventory {
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.";
 
-  revision 2026-01-27 {
+  revision 2026-05-27 {
     description
       "Initial version";
     reference
@@ -101,6 +101,7 @@ module ietf-network-inventory {
     type leafref {
       path "/nwi:network-inventory/nwi:network-elements"
          + "/nwi:network-element/nwi:ne-id";
+      require-instance false;
     }
     description
       "This type is intended to be used by data models that need to
@@ -110,6 +111,28 @@ module ietf-network-inventory {
   /*
    * Groupings
    */
+
+  grouping component-ref {
+    description
+      "This grouping is intended to be used by data models that need
+       to reference a component within a Network Element.";
+    leaf ne-ref {
+      type nwi:ne-ref;
+      description
+        "The reference to the Network Element which contains the
+         component to be referenced.";
+    }
+    leaf component-ref {
+      type leafref {
+        path "/nwi:network-inventory/nwi:network-elements/"
+           + "nwi:network-element[nwi:ne-id=current()/../ne-ref]"
+           + "/nwi:components/nwi:component/nwi:component-id";
+        require-instance false;
+      }
+      description
+        "The reference to the component.";
+    }
+  }
 
   grouping port-ref {
     description
@@ -126,13 +149,13 @@ module ietf-network-inventory {
         path "/nwi:network-inventory/nwi:network-elements/"
            + "nwi:network-element[nwi:ne-id=current()/../ne-ref]"
            + "/nwi:components/nwi:component/nwi:component-id";
+        require-instance false;
       }
-      must "derived-from-or-self (/nwi:network-inventory/
-            nwi:network-elements/nwi:network-element
-            [nwi:ne-id=../ne-ref]/nwi:components/nwi:component
-            [nwi:component-id=current()]/nwi:class, 'ianahw:port')";
       description
-        "The reference to the port component.";
+        "The reference to the port component.
+
+         Note: the class of the referenced port component MUST be
+         'ianahw:port' or a derived identity.";
     }
   }
 
@@ -153,8 +176,8 @@ module ietf-network-inventory {
       description
         "The name of the  entity (e.g., component), as specified by
          a network operator, that provides a non-volatile 'handle'
-         for the entity and that can be modified anytime during the
-         entity lifetime.
+         for the entity. The The network operator can specify a
+         different value anytime during the entity lifetime.
 
          If no value is discovered, the server MAY set the value of
          this node to a locally unique value in the operational
@@ -181,8 +204,9 @@ module ietf-network-inventory {
     list software-rev {
       key "name";
       description
-        "The list of the software modules configured to be active
-         within the entity (e.g., component).";
+        "The list of the software modules representing the software
+         images intended to be running within the entity
+         (e.g., component).";
       leaf name {
         type string;
         description
@@ -432,8 +456,9 @@ module ietf-network-inventory {
                  component among all the sibling components.
 
                  The format of this string is
-                 implementation-specific. It MAY encode an integer
-                 value representing the entPhysicalParentRelPos.";
+                 implementation-specific. When mapping from RFC 6933,
+                 the entPhysicalParentRelPos integer value SHOULD be
+                 encoded as an integer string.";
               reference
                 "RFC 6933: Entity MIB (Version 4) -
                            entPhysicalParentRelPos";
@@ -446,10 +471,15 @@ module ietf-network-inventory {
                 "This node indicates whether the chassis is taking or
                  not the 'main' role.
 
-                 This node is applicable only to scenarios where
-                 there are chassis components which can take the
-                 'main' role (e.g., multi-chassis network elements),
-                 otherwise it is omitted.";
+                 This node is applicable only to scenarios where the
+                 network element contains chassis components which
+                 can take or not the 'main' role (e.g., multi-chassis
+                 network elements).
+
+                 It is therefore omitted in scenarios where the
+                 network element does not contain chassis components
+                 which can can take or not the 'main' role
+                 (e.g., single-chassis network elements).";
             }
           }
         }


### PR DESCRIPTION
Added presence container to allow co-existence of physical/undelay and overlay topology entities within the same network topology instance


---

Preview of the changes:

[Inventory Topology Mapping](https://italobusi.github.io/network-inventory-topology/presence-containers/draft-ietf-ivy-network-inventory-topology.html)
[plain text](https://italobusi.github.io/network-inventory-topology/presence-containers/draft-ietf-ivy-network-inventory-topology.txt)
[diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://ietf-ivy-wg.github.io/network-inventory-topology/draft-ietf-ivy-network-inventory-topology.txt&url_2=https://italobusi.github.io/network-inventory-topology/presence-containers/draft-ietf-ivy-network-inventory-topology.txt)
